### PR TITLE
removed redundant call to moment in tag 3e

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -34,8 +34,3 @@
     {% block page_content %}{% endblock %}
 </div>
 {% endblock %}
-
-{% block scripts %}
-{{ super() }}
-{{ moment.include_moment() }}
-{% endblock %}


### PR DESCRIPTION
in tag 3e, moment was called by both templates/base.html and templates/index.html,
causing the script to be written twice in the HTML response; moment is
only needed by index.html, so I deleted its call from base.html.

P.S., this is my first ever pull request in Git, so I hope I'm doing it right.
