### PR TITLE
Fix url value for JSON-ified user.

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -241,7 +241,7 @@ class User(UserMixin, db.Model):
 
     def to_json(self):
         json_user = {
-            'url': url_for('api.get_post', id=self.id, _external=True),
+            'url': url_for('api.get_user', id=self.id, _external=True),
             'username': self.username,
             'member_since': self.member_since,
             'last_seen': self.last_seen,


### PR DESCRIPTION
A JSON-ified user's `url` key should point to [this endpoint](https://github.com/miguelgrinberg/flasky/blob/579ecd9435b392df114110985f514ad173a315f2/app/api_1_0/users.py#L7). 

I also noticed that you're using `id` as a parameter in some of your API methods, thus shadowing the built-in `id` function (linters will error on this by default), which isn't good but can be fixed pretty easily.

```shell
~ $ python -c "print(id)"
<built-in function id>
```