### PR TITLE
the password_reset_request function

### DIFF
--- a/app/auth/views.py
+++ b/app/auth/views.py
@@ -113,9 +113,11 @@ def password_reset_request():
                        'auth/email/reset_password',
                        user=user, token=token,
                        next=request.args.get('next'))
-        flash('An email with instructions to reset your password has been '
-              'sent to you.')
-        return redirect(url_for('auth.login'))
+            flash('An email with instructions to reset your password has been '
+                  'sent to you.')
+            return redirect(url_for('auth.login'))
+        else:
+            flash('Invalid email.')
     return render_template('auth/reset_password.html', form=form)
 
 


### PR DESCRIPTION
When someone wants to reset the password, but the email he inputs is wrong and doesn't exist in the database, so the 'user' is None,  it should flash 'Invalid email' or something, and redirect to the 'auth/reset_password.html' page.