### PR TITLE
Changed MarkupSafe version to 1.1 to avoid error

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -18,7 +18,7 @@ itsdangerous==0.24
 Jinja2==2.9.6
 Mako==1.0.7
 Markdown==2.6.8
-MarkupSafe==1.0
+MarkupSafe==1.1
 python-dateutil==2.6.1
 python-dotenv==0.6.5
 python-editor==1.0.3


### PR DESCRIPTION
MarkupSafe 1.0 was throwing errors with regards to setuptools. This issue explains it was only a problem for 1.1: https://github.com/pallets/markupsafe/issues/57