### PR TITLE
建议使用 os.environ.get('SERVER_NAME') 替代 os.environ['SERVER_NAME']

### DIFF
--- a/config.py
+++ b/config.py
@@ -42,7 +42,7 @@ class TestingConfig(Config):
 class ProductionConfig(Config):
     SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or \
         'sqlite:///' + os.path.join(basedir, 'data.sqlite')
-    SERVER_NAME = os.environ['SERVER_NAME']  # configure the domain name in use
+    SERVER_NAME = os.environ.get('SERVER_NAME')  # configure the domain name in use
 
     @classmethod
     def init_app(cls, app):


### PR DESCRIPTION
此 PR 建议将代码中使用的 os.environ['SERVER_NAME'] 替换为 os.environ.get('SERVER_NAME')。

修改原因：

- os.environ['SERVER_NAME'] 在 SERVER_NAME 环境变量未设置时会引发 KeyError 异常，导致程序崩溃。
- os.environ.get('SERVER_NAME') 在环境变量未设置时返回 None，避免异常，使代码更健壮。

修改内容：

- 将所有 os.environ['SERVER_NAME'] 替换为 os.environ.get('SERVER_NAME')。

测试：

- 已在本地测试，确保代码在 SERVER_NAME 环境变量未设置时不会引发异常。

影响范围：

- 此修改影响所有使用 os.environ['SERVER_NAME'] 的代码。

建议：

- 建议合并此 PR，以提高代码的健壮性。